### PR TITLE
Feature/164569040/user settings

### DIFF
--- a/controllers/settingsController.js
+++ b/controllers/settingsController.js
@@ -1,0 +1,75 @@
+import models from '../models';
+import logger from '../helpers/logger';
+import Response from '../helpers/responseHelper';
+import { STATUS } from '../helpers/constants';
+
+const { Setting } = models;
+/**
+ * @description - This class represents user settings in the api
+ * @class SettingsController
+ */
+class SettingsController {
+  /**
+   * This function creates a user setting
+   * @param {int} userId - The users Id
+   * @returns {void}
+   */
+  static async create(userId) {
+    // create a user
+    const data = await Setting.create({ user_id: userId });
+    return data;
+  }
+
+  /**
+   * This function updates a users setting
+   * @param {Object} request - This is the request object
+   * @param {Object} response - This is the response object
+   * @returns {Object} - This function returns a response object
+   */
+  static async update(request, response) {
+    // get the user id from the request
+    const userId = request.user.id;
+    // get the settings for this user and update
+    try {
+      const updateData = await Setting.update(
+        {
+          canEmail: request.body.canEmail,
+          canNotify: request.body.canNotify
+        },
+        {
+          where: { user_id: userId }
+        }
+      );
+      if (!updateData) {
+        return Response.send(response, STATUS.BAD_REQUEST, null, 'An error occurred while updating your settings', false);
+      }
+      return Response.send(response, STATUS.OK, null, 'Settings have been successfully updated');
+    } catch (e) {
+      logger.log(e);
+      return Response.send(response, STATUS.BAD_REQUEST, null, 'An error occurred while updating your settings', false);
+    }
+  }
+
+  /**
+   * This function updates a users setting
+   * @param {Object} request - This is the request object
+   * @param {Object} response - This is the response object
+   * @returns {Object} - This function returns a response object
+   */
+  static async getUserSetting(request, response) {
+    // get the user id from the request
+    const userId = request.user.id;
+
+    // get a users setting
+    try {
+      const { dataValues } = await Setting.findOne({ where: { user_id: userId } });
+      const setting = dataValues;
+      return Response.send(response, STATUS.OK, setting, 'Successful');
+    } catch (e) {
+      logger.log(e);
+      return Response.send(response, STATUS.BAD_REQUEST, null, 'An error occurred', false);
+    }
+  }
+}
+
+export default SettingsController;

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -7,6 +7,7 @@ import Response from '../helpers/responseHelper';
 import { STATUS, MESSAGE } from '../helpers/constants';
 import logger from '../helpers/logger';
 
+
 const { User } = models;
 
 /**
@@ -52,6 +53,8 @@ class UsersController {
       user.username = request.body.username.toLowerCase();
       user.user_id = user.id;
       await models.Profile.create(user);
+      // create a user default settings
+      await models.Setting.create({ user_id: user.user_id });
       Response.send(response, STATUS.CREATED, { token, id: user.id });
       await Mail.sendMail(data);
       return;

--- a/database/migrations/20190312152110-create-settings.js
+++ b/database/migrations/20190312152110-create-settings.js
@@ -1,0 +1,38 @@
+
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('settings', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    canEmail: {
+      type: Sequelize.BOOLEAN,
+      defaultValue: true
+    },
+    canNotify: {
+      type: Sequelize.BOOLEAN,
+      defaultValue: true
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    user_id: {
+      allowNull: false,
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'users',
+        key: 'id',
+      }
+    },
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('settings')
+};

--- a/middlewares/handleValidation.js
+++ b/middlewares/handleValidation.js
@@ -67,7 +67,7 @@ export default class Handler {
   static handleValidation(req, res, next) {
     const errors = validationResult(req).formatWith(expressValidatorFormater);
     if (!errors.isEmpty()) {
-      return res.status(400).json({ status: 400, error: errors.array({ onlyFirstError: true }) });
+      return Response.send(res, 400, errors.array({ onlyFirstError: true }), 'Validation error occurred', false);
     }
     next();
   }

--- a/middlewares/handleValidation.js
+++ b/middlewares/handleValidation.js
@@ -1,6 +1,7 @@
 import { validationResult } from 'express-validator/check';
 import { STATUS, MESSAGE, expressValidatorFormater } from '../helpers/constants';
 import Response from '../helpers/responseHelper';
+
 /**
  * Wrapper class to handle validation results from exprsss-validator
  *
@@ -51,6 +52,22 @@ export default class Handler {
         message,
         false,
       );
+    }
+    next();
+  }
+
+  /**
+   * This function checks for validation error and returns an error or allows the request process
+   * to proceed to the controller
+   * @param {Object} req - inccoming request object
+   * @param {Object} res - response object
+   * @param {Object} next - next object
+   * @return {Object} res - response object
+   */
+  static handleValidation(req, res, next) {
+    const errors = validationResult(req).formatWith(expressValidatorFormater);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ status: 400, error: errors.array({ onlyFirstError: true }) });
     }
     next();
   }

--- a/middlewares/validator.js
+++ b/middlewares/validator.js
@@ -118,4 +118,19 @@ export default class Validator {
         }),
     ];
   }
+
+  /**
+   * Verifies the input data for user settings
+   * @static
+   * @returns {array} The array of express validator chains
+   * @memberof Validator
+   */
+  static validateSettings() {
+    return [
+      body('canEmail', 'A valid value is required').exists()
+        .isBoolean(),
+      body('canNotify', 'A valid value is required').exists()
+        .isBoolean(),
+    ];
+  }
 }

--- a/models/Setting.js
+++ b/models/Setting.js
@@ -1,0 +1,43 @@
+/**
+ * A model class representing settings on the databse
+ *
+ * @param {Sequelize} sequelize - Sequelize object
+ * @param {Sequelize.DataTypes} DataTypes - A convinient object holding data types
+ * @return {Sequelize.Model} - Application Settings Model
+ */
+
+const Setting = (sequelize, DataTypes) => {
+  /**
+   * @type {Sequelize.Model}
+   */
+  const SettingSchema = sequelize.define('setting', {
+    canEmail: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: true
+    },
+    canNotify: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: true
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: sequelize.NOW
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: sequelize.NOW,
+      onUpdate: sequelize.NOW
+    }
+  }, {});
+
+  SettingSchema.associate = (models) => {
+    SettingSchema.belongsTo(models.User, {
+      foreignKey: 'user_id',
+      targetKey: 'id',
+      onDelete: 'CASCADE'
+    });
+  };
+  return SettingSchema;
+};
+
+export default Setting;

--- a/models/index.js
+++ b/models/index.js
@@ -16,6 +16,7 @@ const models = {
   User: sequelize.import('./User.js'),
   Profile: sequelize.import('./Profile.js'),
   Article: sequelize.import('./Article.js'),
+  Setting: sequelize.import('./Setting.js'),
   ArticleLike: sequelize.import('./ArticleLikes.js'),
 };
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ import users from './users';
 import profile from './profile';
 import authRoute from './auth';
 import articles from './articles';
+import settingRouter from './settings';
 
 const router = express.Router();
 
@@ -24,5 +25,7 @@ router.use('/users', users);
 router.use(profile);
 router.use(articles);
 router.use('/auth', authRoute);
+router.use('/articles', articles);
+router.use('/setting', settingRouter);
 
 export default router;

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -1,0 +1,68 @@
+import express from 'express';
+import settingController from '../controllers/settingsController';
+import middlewares from '../middlewares';
+import Handler from '../middlewares/handleValidation';
+import Validator from '../middlewares/validator';
+
+
+const settingRouter = express.Router();
+
+/**
+* /api/v1/setting:
+*  put:
+*    tags:
+*      - Settings
+*    description: Uppdate a users setting
+*    produces:
+*       - application/json
+*    parameters:
+*      - name: canEmail
+*        description: Enables or disables user email notification
+*        in: body
+*        required: false
+*        type: boolean
+*      - name: canNotify
+*        description: Enables or disables user notification
+*        in: body
+*        required: false
+*        type: boolean
+*    responses:
+*      200:
+*        description: User setting updated
+*        schema:
+*          type: object
+*/
+settingRouter.put(
+  '/',
+  middlewares.authenticate,
+  Validator.validateSettings(),
+  Handler.handleValidation,
+  settingController.update
+);
+
+/**
+* /api/v1/setting:
+*  get:
+*    tags:
+*      - Settings
+*    description: Gets a users setting
+*    produces:
+*       - application/json
+*    parameters:
+*      - name: token
+*        description: The confirmation token
+*        in: query
+*        required: true
+*        type: string
+*    responses:
+*      200:
+*        description: Settings fetched successfully
+*        schema:
+*          type: object
+*/
+settingRouter.get(
+  '/',
+  middlewares.authenticate,
+  settingController.getUserSetting
+);
+export default settingRouter;

--- a/test/integrations/routes/settings.test.js
+++ b/test/integrations/routes/settings.test.js
@@ -40,6 +40,7 @@ describe('Settings endpoints Tests', () => {
     expect(response).to.have.status(200);
     expect(response.body).to.be.an('object');
     expect(response.body).to.haveOwnProperty('code');
+    expect(response.body).to.haveOwnProperty('data');
   });
   it('should not update an un authenticated user settings', async () => {
     const setting = {
@@ -67,6 +68,8 @@ describe('Settings endpoints Tests', () => {
     expect(response).to.have.status(400);
     expect(response.body).to.be.an('object');
     expect(response.body).to.haveOwnProperty('code');
+    expect(response.body).to.haveOwnProperty('status');
+    expect(response.body).to.haveOwnProperty('data').to.be.an('array');
   });
 
   it('should not update an a user settings with a bad (empty) request', async () => {
@@ -88,6 +91,8 @@ describe('Settings endpoints Tests', () => {
       .set({ Authorization: `Bearer ${userToken}` });
     expect(response).to.have.status(200);
     expect(response.body).to.be.an('object');
+    expect(response.body).to.haveOwnProperty('status');
+    expect(response.body).to.haveOwnProperty('code');
   });
 
   it('should not get settings for an unauthenticated user', async () => {

--- a/test/integrations/routes/settings.test.js
+++ b/test/integrations/routes/settings.test.js
@@ -39,6 +39,7 @@ describe('Settings endpoints Tests', () => {
       .send(setting);
     expect(response).to.have.status(200);
     expect(response.body).to.be.an('object');
+    expect(response.body).to.haveOwnProperty('code');
   });
   it('should not update an un authenticated user settings', async () => {
     const setting = {
@@ -65,6 +66,7 @@ describe('Settings endpoints Tests', () => {
       .send(setting);
     expect(response).to.have.status(400);
     expect(response.body).to.be.an('object');
+    expect(response.body).to.haveOwnProperty('code');
   });
 
   it('should not update an a user settings with a bad (empty) request', async () => {

--- a/test/integrations/routes/settings.test.js
+++ b/test/integrations/routes/settings.test.js
@@ -1,0 +1,104 @@
+/* eslint-disable no-unused-expressions */
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import faker from 'faker';
+import logger from '../../../helpers/logger';
+import app from '../../../index';
+
+chai.use(chaiHttp);
+let userToken;
+
+// this creates a user and its associate settigs first before tests
+before(async () => {
+  const user = {
+    email: faker.internet.email(),
+    password: faker.internet.password(),
+    username: 'lemmonJunn',
+  };
+  try {
+    const response = await chai
+      .request(app)
+      .post('/api/v1/users')
+      .send(user);
+    userToken = response.body.data.token;
+  } catch (e) {
+    logger.log(e);
+  }
+});
+
+describe('Settings endpoints Tests', () => {
+  it('should update a users setting', async () => {
+    const setting = {
+      canEmail: false,
+      canNotify: true
+    };
+    const response = await chai
+      .request(app)
+      .put('/api/v1/setting')
+      .set({ Authorization: `Bearer ${userToken}` })
+      .send(setting);
+    expect(response).to.have.status(200);
+    expect(response.body).to.be.an('object');
+  });
+  it('should not update an un authenticated user settings', async () => {
+    const setting = {
+      canEmail: false,
+      canNotify: true
+    };
+    const response = await chai
+      .request(app)
+      .put('/api/v1/setting')
+      .set({ Authorization: '' })
+      .send(setting);
+    expect(response).to.have.status(401);
+    expect(response.body).to.be.an('object');
+  });
+  it('should not update an a user settings with a bad request', async () => {
+    const setting = {
+      canEmail: false,
+      canNotify: 'wello'
+    };
+    const response = await chai
+      .request(app)
+      .put('/api/v1/setting')
+      .set({ Authorization: `Bearer ${userToken}` })
+      .send(setting);
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+  });
+
+  it('should not update an a user settings with a bad (empty) request', async () => {
+    const setting = {
+    };
+    const response = await chai
+      .request(app)
+      .put('/api/v1/setting')
+      .set({ Authorization: `Bearer ${userToken}` })
+      .send(setting);
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+  });
+
+  it('should get a users setting', async () => {
+    const response = await chai
+      .request(app)
+      .get('/api/v1/setting')
+      .set({ Authorization: `Bearer ${userToken}` });
+    expect(response).to.have.status(200);
+    expect(response.body).to.be.an('object');
+  });
+
+  it('should not get settings for an unauthenticated user', async () => {
+    const setting = {
+      canEmail: false,
+      canNotify: true
+    };
+    const response = await chai
+      .request(app)
+      .get('/api/v1/setting')
+      .set({ Authorization: 'dkk' })
+      .send(setting);
+    expect(response).to.have.status(401);
+    expect(response.body).to.be.an('object');
+  });
+});

--- a/test/unit/middlewares/socialAuth.test.js
+++ b/test/unit/middlewares/socialAuth.test.js
@@ -1,19 +1,16 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
-import app from '../../../index';
 import { generateOrFindUser } from '../../../auth/passport';
 
 chai.use(chaiHttp);
-
 describe('social authentication', () => {
-  
   describe('verify callback', () => {
     const verifyCallback = {
       accessToken: 'vcjhdcyusdvchcv',
       refreshToken: undefined,
       profile: {
         id: 4,
-        emails: [{value:'testing@test1.com'}]
+        emails: [{ value: 'testing@test1.com' }]
       },
     };
     it('should hit socail authentication API', async () => {
@@ -22,8 +19,9 @@ describe('social authentication', () => {
         verifyCallback.refreshToken,
         verifyCallback.profile,
       );
+      // eslint-disable-next-line no-unused-expressions
       expect(facebookUserInfo).to.be.empty;
-      expect(typeof(facebookUserInfo)).to.equal('object');
+      expect(typeof (facebookUserInfo)).to.equal('object');
       expect(verifyCallback.accessToken).to.be.a('string');
       expect(verifyCallback.profile).to.an('object');
     });

--- a/test/unit/models/settings.test.js
+++ b/test/unit/models/settings.test.js
@@ -1,0 +1,25 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import faker from 'faker';
+import models from '../../../models/index';
+
+chai.use(chaiHttp);
+
+describe('Settings Model', () => {
+  it('should create a user with settings', async () => {
+    const dummyUser = {
+      email: faker.internet.email(),
+      password: 'l23456787960',
+      username: 'hddjjhfjuieiu',
+      firstname: '',
+      lastname: '',
+      bio: '',
+      gender: '',
+    };
+    const { dataValues: { id } } = await models.User.create(dummyUser);
+    dummyUser.user_id = id;
+    console.log(id);
+    const data = models.Setting.create({ user_id: dummyUser.user_id });
+    expect(data).to.be.an('object');
+  });
+});

--- a/test/unit/models/settings.test.js
+++ b/test/unit/models/settings.test.js
@@ -18,7 +18,6 @@ describe('Settings Model', () => {
     };
     const { dataValues: { id } } = await models.User.create(dummyUser);
     dummyUser.user_id = id;
-    console.log(id);
     const data = models.Setting.create({ user_id: dummyUser.user_id });
     expect(data).to.be.an('object');
   });


### PR DESCRIPTION
**What does this PR do?**
This PR enables users to have settings for the application, update and fetch them, these settings are stored in the database on this api. 

**Tasks to be completed?**
- enable settings migrations
- create setting model
- create setting controller
- enable default setting creating for a new user
- update setting controller function
- setting update route
- setting controller get
- getsetting route
- validation for update setting
- new validation handler (middleware)

**How can this be manually tested?**
- clone the repo
- install postgress node js and yarn
- create .env and .test.env from .example.env
- run `yarn run migrate` 
- run `yarn ru start:dev`
- send a POST request to `/api/v1/users` this creates a user and his default settings
- send a PUT request to `/api/v1/setting` with the setting 
- api documentation at `/api-docs/`
- send GET request to `/api/v1/setting` this gets all the settings of an authenticated user

**Relevant PT stories?**
`164569040`