### PR TITLE
#165378249 fix article slug bug

### DIFF
--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -31,7 +31,7 @@ class UsersController {
     const { body } = request;
 
     try {
-      const user = await User.create(body, { raw: true });
+      const user = await User.create(body);
       const role = await models.Role.findOne({ where: { name: 'user' } });
       await user.setRole(role);
       const token = await generateToken({ user });

--- a/server/helpers/nestedDataProvider.js
+++ b/server/helpers/nestedDataProvider.js
@@ -1,0 +1,55 @@
+import models from '../models';
+
+
+const userModelObj = {
+  model: models.User,
+  attributes: {
+    exclude: ['email', 'password', 'updatedAt', 'isConfirmed', 'createdAt', 'deletedAt'],
+  },
+  include: [{
+    model: models.Profile,
+    attributes: ['firstname', 'lastname', 'username', 'bio', 'image'],
+    required: true,
+  }],
+};
+
+const tagsModelObj = {
+  model: models.Tag,
+  as: 'tagList',
+  attributes: {
+    exclude: [''],
+  },
+};
+
+const articleCategoryModelObj = {
+  model: models.ArticleCategory,
+  as: 'articleCategory',
+  attributes: { exclude: ['id'] },
+  required: true,
+};
+
+const ratingsModelObj = {
+  model: models.ratings,
+  attributes: ['stars', 'userId']
+};
+
+/**
+ *
+ *
+ * @param {*} categoryQuery - category Id needed to query the database
+ * @param {*} authorQuery - author name needed to query the DB
+ * @param {*} tagQuery - tag name needed to query the DB
+ * @returns {Array} - An array of the user model, tags model, and ratings model
+ */
+const dataProvider = (categoryQuery, authorQuery, tagQuery) => {
+  if (authorQuery) userModelObj.include[0].where = { ...authorQuery };
+  if (tagQuery) {
+    tagsModelObj.required = tagQuery.tagName !== undefined;
+    tagsModelObj.where = { ...tagQuery };
+  }
+  if (categoryQuery) articleCategoryModelObj.where = { ...categoryQuery };
+
+  return ([userModelObj, tagsModelObj, articleCategoryModelObj, ratingsModelObj]);
+};
+
+export default dataProvider;

--- a/server/middlewares/articlesMiddleware.js
+++ b/server/middlewares/articlesMiddleware.js
@@ -61,6 +61,10 @@ export default class AriclesMiddleware {
       return Response.send(res, STATUS.BAD_REQUEST, [], 'category cannot be empty', false);
     }
 
+    if (description.length > 255) {
+      return Response.send(res, STATUS.BAD_REQUEST, [], 'description can only be 255 characters maximum', false);
+    }
+
     try {
       const foundArticle = await articleHelpers.findArticleByAuthorId(authorId, title);
       if (foundArticle && foundArticle.title === title) {

--- a/server/middlewares/articlesMiddleware.js
+++ b/server/middlewares/articlesMiddleware.js
@@ -74,8 +74,8 @@ export default class AriclesMiddleware {
       if (!categoryFound) {
         return Response.send(res, STATUS.BAD_REQUEST, [], 'category does not exist', false);
       }
-      const slug = slugify(`${title}-${uuid()}`, {
-        remove: /[*+~.()'"!:@]/g,
+      const trimmedTitle = title.replace(/[^a-z0-9]/gi, '');
+      const slug = slugify(`${trimmedTitle}-${uuid()}`, {
         replacement: '-',
         lower: true
       });
@@ -147,8 +147,8 @@ export default class AriclesMiddleware {
         return Response.send(res, STATUS.FORBIDDEN, [], 'you do not have the right to update this article', false);
       }
       if (title) {
-        const slug = slugify(`${title}-${uuid()}`, {
-          remove: /[*+~.()'"!:@]/g,
+        const trimmedTitle = title.replace(/[^a-z0-9]/gi, '');
+        const slug = slugify(`${trimmedTitle}-${uuid()}`, {
           replacement: '-',
           lower: true
         });

--- a/server/middlewares/validator.js
+++ b/server/middlewares/validator.js
@@ -45,10 +45,6 @@ export default class Validator {
   static validateUpdateProfile() {
     return [
       ...Validator.validateUpdateUsername(),
-      ...Validator.validateFirstname(),
-      ...Validator.validateLastname(),
-      ...Validator.validateBio(),
-      ...Validator.validateImageURL()
     ];
   }
 

--- a/test/integrations/routes/profile.test.js
+++ b/test/integrations/routes/profile.test.js
@@ -68,42 +68,6 @@ describe('Testing user profile feature', () => {
       });
   });
 
-  it('should return an error if firstname is not provided', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/profiles')
-      .send({ ...profile, firstname: '' })
-      .set('Authorization', `Bearer ${dummyUser3.token}`)
-      .end((err, res) => {
-        expect(res.status).eql(BAD_REQUEST);
-        expect(res.body).to.have.property('status').equal(false);
-        expect(res.body).to.have.property('code').equal(400);
-        expect(res.body).to.have.property('message').equal(MESSAGE.PROFILE_UPDATE_ERROR);
-        expect(res.body).to.have.property('data');
-        expect(res.body.data[0].field).to.be.equals('firstname');
-        expect(res.body.data[0].message).to.be.equals('Firstname is required');
-        done();
-      });
-  });
-
-  it('should return an error if lastname is not provided', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/profiles')
-      .send({ ...profile, lastname: '' })
-      .set('Authorization', `Bearer ${dummyUser3.token}`)
-      .end((err, res) => {
-        expect(res.status).eql(BAD_REQUEST);
-        expect(res.body).to.have.property('status').equal(false);
-        expect(res.body).to.have.property('code').equal(400);
-        expect(res.body).to.have.property('message').equal(MESSAGE.PROFILE_UPDATE_ERROR);
-        expect(res.body).to.have.property('data');
-        expect(res.body.data[0].field).to.be.equals('lastname');
-        expect(res.body.data[0].message).to.be.equals('Lastname is required');
-        done();
-      });
-  });
-
   it('should return error if username is not provided', (done) => {
     chai
       .request(app)
@@ -118,42 +82,6 @@ describe('Testing user profile feature', () => {
         expect(res.body).to.have.property('data');
         expect(res.body.data[0].field).to.be.equals('username');
         expect(res.body.data[0].message).to.be.equals('Username is required');
-        done();
-      });
-  });
-
-  it('should throw an error if bio is not provided', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/profiles')
-      .send({ ...profile, bio: '' })
-      .set('Authorization', `Bearer ${dummyUser3.token}`)
-      .end((err, res) => {
-        expect(res.status).eql(BAD_REQUEST);
-        expect(res.body).to.have.property('status').equal(false);
-        expect(res.body).to.have.property('code').equal(400);
-        expect(res.body).to.have.property('message').equal(MESSAGE.PROFILE_UPDATE_ERROR);
-        expect(res.body).to.have.property('data');
-        expect(res.body.data[0].field).to.be.equals('bio');
-        expect(res.body.data[0].message).to.be.equals('Bio is required');
-        done();
-      });
-  });
-
-  it('should throw an error if image url is invalid', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/profiles')
-      .send({ ...profile, image: 'hffhh.cam' })
-      .set('Authorization', `Bearer ${dummyUser3.token}`)
-      .end((err, res) => {
-        expect(res.status).eql(BAD_REQUEST);
-        expect(res.body).to.have.property('status').equal(false);
-        expect(res.body).to.have.property('code').equal(400);
-        expect(res.body).to.have.property('message').equal(MESSAGE.PROFILE_UPDATE_ERROR);
-        expect(res.body).to.have.property('data');
-        expect(res.body.data[0].field).to.be.equals('image');
-        expect(res.body.data[0].message).to.be.equals('image URL is not valid');
         done();
       });
   });

--- a/test/unit/middlewares/articlesMiddleware.test.js
+++ b/test/unit/middlewares/articlesMiddleware.test.js
@@ -233,6 +233,27 @@ describe('API endpoint: /api/articles (Middleware test)', () => {
   });
 
   describe('POST: /api/v1/articles', () => {
+    describe('create an article with a lengthy description', () => {
+      it('Should return an error', (done) => {
+        const article = { ...dummyArticle };
+        article.description = 'After the success of Peloton’s stationary bike — it has sold hundreds of thousands, though the company won’t provide specifics — Peloton is aggressively expanding to become a full-body, full-service fitness and technology company, and it’s forcing the rest of the industry to follow suit or fall behind.';
+        chai
+          .request(app)
+          .post('/api/v1/articles')
+          .send(article)
+          .set({ Authorization: `Bearer ${dummyUser.token}` })
+          .end((err, res) => {
+            expect(res).to.have.status(BAD_REQUEST);
+            expect(res.body).to.be.an('object');
+            expect(res.body).to.haveOwnProperty('code').to.equal(BAD_REQUEST);
+            expect(res.body.message).to.equal('description can only be 255 characters maximum');
+            done();
+          });
+      });
+    });
+  });
+
+  describe('POST: /api/v1/articles', () => {
     describe('create an article with a description of numbers', () => {
       it('Should return an error', (done) => {
         const article = { ...dummyArticle };


### PR DESCRIPTION
#### What does this PR do?

- exclude special characters from slug
- include author profile, taglist, categories to single article
- refactor getAllArticles feature

#### How should this be manually tested?

- follow set up instruction from this [link](https://github.com/andela/apollo-ah-backend/tree/chore/164859311/update-readme#set-up)

- create a user from the ```/users/``` route
- make sure payload is in this format
```
{
  "email": "dbrandy@email.com",
  "password": "!23ijdkdhfhf",
  "username": "username101",
}
```
- copy token from the response object

- visit the create articles route ```/articles/``` to create an article
- add token from the response in the header like in the format below
```
Authorization: Bearer (insert-your-token-here)
```
- make sure you provide the payload to create an article in this format
```
{
  "title": "bvdd",
  "body": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
  "description": "hddkjkd",
  "categoryId": 1,
  "image": "link.to.image.url",
  "tagList": ["tech"]
}
```
- copy the slug from the response object
- visit the get single article routes `/articles/:slug` and provide the slug after the `articles/`
- make sure you don't include the `:` after `articles/`
- you will get a response with the user profile, taglist, ratings object attached to the article response object


#### What are the relevant pivotal tracker stories?

[#165378249](https://www.pivotaltracker.com/story/show/165378249)

![backend-sample](https://user-images.githubusercontent.com/24186167/56211432-d1cbfb80-604f-11e9-9423-5492c505c4ae.gif)

