### PR TITLE
#165686079 implement like and dislike feature

### DIFF
--- a/server/controllers/commentLikesController.js
+++ b/server/controllers/commentLikesController.js
@@ -33,72 +33,81 @@ class CommentLikeController {
   static async likeComment(req, res) {
     const { slug, commentId } = req.params;
     const userId = req.user.id;
-    let updatedLike;
+
     try {
-      const articleFound = await Article.findOne({
-        where: {
-          slug
-        }
-      });
-      if (!articleFound) {
-        return Response.send(res, NOT_FOUND, [], 'This article no longer exist', false);
-      }
-      const commentFound = await Comment.findOne({
-        where: {
-          id: commentId,
-        }
-      });
-      if (!commentFound) {
-        return Response.send(res, NOT_FOUND, [], 'This comment does not exist', false);
-      }
+      const articleFound = await Article.findOne({ where: { slug } });
+      if (!articleFound) return Response.send(res, NOT_FOUND, [], 'This article no longer exist', false);
+      const commentFound = await Comment.findOne({ where: { id: commentId, } });
+      if (!commentFound) return Response.send(res, NOT_FOUND, [], 'This comment does not exist', false);
 
-      const likeFound = await CommentLike.findOne({
-        where: {
-          commentId,
-          userId
-        }
-      });
-
-      if (likeFound && likeFound.like) {
-        [, updatedLike] = await CommentLike.update(
-          { like: false, userId, commentId },
-          {
-            where: {
-              commentId,
-              userId
-            },
-            returning: true,
-            plain: true
-          }
-        );
-        return Response.send(res, OK, updatedLike, 'successfully disliked comment', true);
-      }
+      const likeFound = await CommentLike.findOne({ where: { commentId, userId } });
 
       if (likeFound && !likeFound.like) {
-        [, updatedLike] = await CommentLike.update(
+        await CommentLike.destroy({ where: { userId, commentId } });
+        const likedComment = await CommentLike.create(
           { like: true, userId, commentId },
-          {
-            where: {
-              commentId,
-              userId
-            },
-            returning: true,
-            plain: true
-          }
+          { where: { commentId, userId } }
         );
-        return Response.send(res, OK, updatedLike, 'successfully liked comment', true);
+        return Response.send(res, CREATED, likedComment, 'successfully liked comment', true);
       }
+
+      if (likeFound && likeFound.like) {
+        await CommentLike.destroy({ where: { commentId, userId } });
+        return Response.send(res, OK, [], 'successfully removed like from comment', true);
+      }
+
       const newLike = await CommentLike.create(
         { like: true, userId, commentId },
-        {
-          where: {
-            commentId,
-            userId
-          }
-        }
+        { where: { commentId, userId } }
       );
 
       return Response.send(res, CREATED, newLike, 'successfully liked comment', true);
+    } catch (error) {
+      return Response.send(res, SERVER_ERROR, error.message, 'sorry! something went wrong', false);
+    }
+  }
+
+  /**
+   *
+   * @description dislike a user's comment
+   * @static
+   * @param {*} req
+   * @param {*} res
+   * @returns {object} - The disliked comment's object
+   * @memberof CommentLikeController
+   */
+  static async dislikeComment(req, res) {
+    const { slug, commentId } = req.params;
+    const userId = req.user.id;
+
+    try {
+      const articleFound = await Article.findOne({ where: { slug } });
+      if (!articleFound) return Response.send(res, NOT_FOUND, [], 'This article no longer exist', false);
+      const commentFound = await Comment.findOne({ where: { id: commentId, } });
+      if (!commentFound) return Response.send(res, NOT_FOUND, [], 'This comment does not exist', false);
+
+      const likeFound = await CommentLike.findOne({ where: { commentId, userId, } });
+
+      if (likeFound && likeFound.like) {
+        await CommentLike.destroy({ where: { userId, commentId } });
+        const dislike = await CommentLike.create(
+          { like: false, userId, commentId },
+          { where: { commentId, userId } }
+        );
+        return Response.send(res, CREATED, dislike, 'successfully disliked comment', true);
+      }
+
+      if (likeFound && !likeFound.like) {
+        await CommentLike.destroy({ where: { commentId, userId } });
+        return Response.send(res, OK, [], 'successfully removed dislike from comment', true);
+      }
+
+      const dislike = await CommentLike.create(
+        { like: false, userId, commentId },
+        { where: { commentId, userId } }
+      );
+
+      return Response.send(res, CREATED, dislike, 'successfully disliked comment', true);
     } catch (error) {
       return Response.send(res, SERVER_ERROR, error.message, 'sorry! something went wrong', false);
     }

--- a/server/controllers/commentsController.js
+++ b/server/controllers/commentsController.js
@@ -1,8 +1,9 @@
 import models from '../models';
 import Response from '../helpers/responseHelper';
 import { STATUS } from '../helpers/constants';
-import paginationHelper from '../helpers/articleHelpers';
+import paginationHelper, { squashLikesAndDislikes } from '../helpers/articleHelpers';
 import Logger from '../helpers/logger';
+// import squashLikesAndDislikes from '../helpers/articleHelpers';
 
 /**
  * Wrapper class for sending comments objects as response.
@@ -68,13 +69,17 @@ export default class CommentsController {
           },
           {
             model: models.CommentHistory,
-          }
+          },
+          {
+            model: models.CommentLike,
+          },
         ],
         attributes: {},
         limit,
         offset,
         order: [['createdAt']]
       });
+      comments.rows = squashLikesAndDislikes(comments.rows);
       const {
         code, data, status
       } = paginationHelper.getResourcesAsPages(req, comments);

--- a/server/helpers/articleHelpers.js
+++ b/server/helpers/articleHelpers.js
@@ -31,6 +31,29 @@ export const squashClaps = (resource) => {
   return resource;
 };
 
+/**
+ * calculates the number of likes and dislikes for a single comment
+ *
+ * @param {*} resource - the comment object
+ * @returns {object} - returns either the like and dislike count or the initial comment object
+ */
+
+export const squashLikesAndDislikes = (resource) => {
+  let comment;
+
+  if (Array.isArray(resource)) {
+    return resource.map((singleComment) => {
+      const total = singleComment.CommentLikes.length;
+      comment = singleComment.get({ plain: true });
+      comment.likes = comment.CommentLikes.filter(post => post.like === true).length;
+      comment.dislikes = total - comment.likes;
+      delete comment.CommentLikes;
+      return comment;
+    });
+  }
+  return resource;
+};
+
 export default {
   findArticleByAuthorId: async (authorId, title) => {
     try {

--- a/server/routes/comments.js
+++ b/server/routes/comments.js
@@ -256,6 +256,38 @@ comments.get(
  *         type: string
  *     responses:
  *       200:
+ *         description: successfully disliked comment
+ *         schema:
+ *           $ref: '#/definitions/Comments'
+ */
+comments.post(
+  '/:slug/comments/:commentId/dislikes',
+  authenticate,
+  commentLikeController.dislikeComment,
+);
+
+/**
+ * @swagger
+ * /api/v1/articles/:slug/comments/:commentId/dislikes:
+ *   get:
+ *     tags:
+ *       - comments
+ *     description: Returns all dislikes
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: slug
+ *         description: slug for the article
+ *         in: query
+ *         required: true
+ *         type: string
+ *       - name: commentId
+ *         description: id for the comment
+ *         in: query
+ *         required: true
+ *         type: string
+ *     responses:
+ *       200:
  *         description: likes successfully fetched
  *         schema:
  *           $ref: '#/definitions/Comments'

--- a/test/integrations/routes/comments.test.js
+++ b/test/integrations/routes/comments.test.js
@@ -244,7 +244,7 @@ describe('API endpoint: /api/articles/:slug/comments/:id/likes (Routes)', () => 
       });
   });
 
-  it('Should dislike a comment', (done) => {
+  it('Should remove liked comment', (done) => {
     chai
       .request(app)
       .post(`/api/v1/articles/${newSlug}/comments/${newCommentId}/likes`)
@@ -253,6 +253,20 @@ describe('API endpoint: /api/articles/:slug/comments/:id/likes (Routes)', () => 
         expect(res).to.have.status(STATUS.OK);
         expect(res.body).to.be.an('object');
         expect(res.body).to.haveOwnProperty('code').to.equal(STATUS.OK);
+        expect(res.body.message).to.equal('successfully removed like from comment');
+        done();
+      });
+  });
+
+  it('Should dislike a comment', (done) => {
+    chai
+      .request(app)
+      .post(`/api/v1/articles/${newSlug}/comments/${newCommentId}/dislikes`)
+      .set({ Authorization: `Bearer ${authToken}` })
+      .end((err, res) => {
+        expect(res).to.have.status(STATUS.CREATED);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.haveOwnProperty('code').to.equal(STATUS.CREATED);
         expect(res.body.message).to.equal('successfully disliked comment');
         done();
       });
@@ -264,13 +278,28 @@ describe('API endpoint: /api/articles/:slug/comments/:id/likes (Routes)', () => 
       .post(`/api/v1/articles/${newSlug}/comments/${newCommentId}/likes`)
       .set({ Authorization: `Bearer ${authToken}` })
       .end((err, res) => {
-        expect(res).to.have.status(STATUS.OK);
+        expect(res).to.have.status(STATUS.CREATED);
         expect(res.body).to.be.an('object');
-        expect(res.body).to.haveOwnProperty('code').to.equal(STATUS.OK);
+        expect(res.body).to.haveOwnProperty('code').to.equal(STATUS.CREATED);
         expect(res.body.message).to.equal('successfully liked comment');
         done();
       });
   });
+
+  it('Should dislike a comment if liked before', (done) => {
+    chai
+      .request(app)
+      .post(`/api/v1/articles/${newSlug}/comments/${newCommentId}/dislikes`)
+      .set({ Authorization: `Bearer ${authToken}` })
+      .end((err, res) => {
+        expect(res).to.have.status(STATUS.CREATED);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.haveOwnProperty('code').to.equal(STATUS.CREATED);
+        expect(res.body.message).to.equal('successfully disliked comment');
+        done();
+      });
+  });
+
 
   it('Should get all likes', (done) => {
     chai


### PR DESCRIPTION
#### What does this PR do?

- add like and dislike feature
- modify existing like feature to enable dislike functionality

#### How should this be manually tested?

- follow set up instruction from this [link](https://github.com/andela/apollo-ah-backend/tree/chore/164859311/update-readme#set-up)

- branch out from staging to feature/165686079/dislike-comment
- create a user from the ```/users/``` route
- make sure payload is in this format
```
{
  "email": "dbrandy@email.com",
  "password": "!23ijdkdhfhf",
  "username": "username101",
}
```
- copy token from the response object

- visit the create articles route ```/articles/``` to create an article
- add token from the response in the header like in the format below
```
Authorization: Bearer (insert-your-token-here)
```
- make sure you provide the payload to create an article in this format
```
{
  "title": "bvdd",
  "body": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
  "description": "hddkjkd",
  "categoryId": 1,
  "image": "link.to.image.url",
  "tagList": ["tech"]
}
```
- copy the slug from the response object
- visit the create comments routes `/articles/:slug/comments` and make a POST request in this format
```
{body: 'comment body here'}
```
- you will get a response with the comment object attached in the response
- copy the comment id from the response
- visit the likes route `articles/:slug/comments/:commentId/likes` and make a POST request
- visit the dislikes route `articles/:slug/comments/:commentId/dislikes` and make a POST request

#### Any background context you want to provide?

-  you will need to provide the user token for each of the routes mentioned above

#### What are the relevant pivotal tracker stories?

[#165686079](https://www.pivotaltracker.com/story/show/165686079)

#### Screenshots (if appropriate)

![dislike](https://user-images.githubusercontent.com/24186167/56985566-8998f700-6b80-11e9-8c7b-0006afe49bae.gif)
